### PR TITLE
Fix maximum raider level

### DIFF
--- a/src/event/LocalEvents.ts
+++ b/src/event/LocalEvents.ts
@@ -70,7 +70,7 @@ export class SelectionChanged extends BaseEvent {
         this.isReinforcable = !!entityMgr.selection.surface?.isReinforcable()
         this.canPlaceFence = !!entityMgr.selection.surface?.canPlaceFence()
         this.someCarries = entityMgr.selection.raiders.some((r) => !!r.carries)
-        this.everyHasMaxLevel = entityMgr.selection.raiders.every((r) => r.level >= r.stats.Levels)
+        this.everyHasMaxLevel = entityMgr.selection.raiders.every((r) => r.level >= r.stats.Levels - 1)
         RaiderTrainings.values.forEach((training) => this.canDoTraining.set(training, entityMgr.hasTrainingSite(training) && entityMgr.selection.raiders.some((r) => !r.hasTraining(training))))
         RaiderTools.values.forEach((tool) => this.everyHasTool.set(tool, entityMgr.selection.raiders.every((r) => r.hasTool(tool))))
         VehicleUpgrades.values.forEach((upgrade) => this.canInstallUpgrade.set(upgrade, entityMgr.selection.vehicles.some((v) => v.canUpgrade(upgrade))))

--- a/src/game/GuiManager.ts
+++ b/src/game/GuiManager.ts
@@ -122,7 +122,7 @@ export class GuiManager {
         })
         EventBroker.subscribe(EventKey.COMMAND_RAIDER_UPGRADE, () => {
             entityMgr.selection.raiders.forEach((r) => {
-                if (r.level >= r.stats.Levels) return
+                if (r.level >= r.stats.Levels - 1) return
                 const closestToolstation = r.findShortestPath(entityMgr.getRaiderUpgradePathTarget())?.target.building
                 if (closestToolstation) r.setJob(new UpgradeRaiderJob(closestToolstation))
             })

--- a/src/game/model/job/raider/UpgradeRaiderJob.ts
+++ b/src/game/model/job/raider/UpgradeRaiderJob.ts
@@ -25,7 +25,7 @@ export class UpgradeRaiderJob extends RaiderJob {
     onJobComplete(fulfiller: JobFulfiller): void {
         super.onJobComplete(fulfiller)
         if (!this.raider) return
-        if (this.raider.level < this.raider.stats.Levels) {
+        if (this.raider.level < this.raider.stats.Levels - 1) {
             this.raider.level++
             this.raider.worldMgr.ecs.getComponents(this.raider.entity).get(HealthComponent).rockFallDamage = GameConfig.instance.getRockFallDamage(this.raider.entityType, this.raider.level)
         }


### PR DESCRIPTION
Rock raiders could be upgraded to a level beyond their maximum, causing out-of-bounds array index issues.