### PR TITLE
Fix minimum drill time check

### DIFF
--- a/src/game/terrain/Surface.ts
+++ b/src/game/terrain/Surface.ts
@@ -175,7 +175,7 @@ export class Surface {
     }
 
     addDrillTimeProgress(drillTimeSeconds: number, elapsedMs: number, drillPosition: Vector2) {
-        if (this.drillProgress >= 1 || drillTimeSeconds < 1) return
+        if (this.drillProgress >= 1 || drillTimeSeconds <= 0) return
         const drillProgress = elapsedMs / (drillTimeSeconds * 1000)
         this.addDrillProgress(drillProgress, drillPosition)
     }


### PR DESCRIPTION
Upgrading the granite grinder or chrome crusher drill causes it to stop working, because the drill time becomes less than 1.