### PR TITLE
Fix: Display entities on radar

### DIFF
--- a/src/gui/radar/MapView.ts
+++ b/src/gui/radar/MapView.ts
@@ -85,7 +85,7 @@ export class MapView extends BaseElement {
             const entities = this.entitiesByOrder.getOrUpdate(event.mapMarkerType, () => new Map())
             switch (event.change) {
                 case MapMarkerChange.UPDATE:
-                    if (event.position && event.radius) entities.set(event.entity, {x: event.position?.x, z: event.position?.z, r: event.radius})
+                    if (event.position) entities.set(event.entity, {x: event.position.x, z: event.position.z, r: event.radius ?? 0})
                     break
                 case MapMarkerChange.REMOVE:
                     entities.delete(event.entity)


### PR DESCRIPTION
Monsters, raiders and materials don't have a radius.