### PR TITLE
Fix null error when selected entity gets destroyed

### DIFF
--- a/src/game/model/building/BuildingEntity.ts
+++ b/src/game/model/building/BuildingEntity.ts
@@ -128,7 +128,7 @@ export class BuildingEntity {
     }
 
     deselect() {
-        this.worldMgr.ecs.getComponents(this.entity).get(SelectionFrameComponent)?.deselect()
+        this.worldMgr.ecs.getComponents(this.entity)?.get(SelectionFrameComponent)?.deselect()
     }
 
     getDropPosition2D(): Vector2 {

--- a/src/game/model/raider/Raider.ts
+++ b/src/game/model/raider/Raider.ts
@@ -296,7 +296,7 @@ export class Raider implements Updatable, JobFulfiller {
     }
 
     deselect() {
-        this.worldMgr.ecs.getComponents(this.entity).get(SelectionFrameComponent)?.deselect()
+        this.worldMgr.ecs.getComponents(this.entity)?.get(SelectionFrameComponent)?.deselect()
     }
 
     isSelectable(): boolean {

--- a/src/game/model/vehicle/VehicleEntity.ts
+++ b/src/game/model/vehicle/VehicleEntity.ts
@@ -277,7 +277,7 @@ export class VehicleEntity implements Updatable, JobFulfiller {
     }
 
     deselect() {
-        this.worldMgr.ecs.getComponents(this.entity).get(SelectionFrameComponent)?.deselect()
+        this.worldMgr.ecs.getComponents(this.entity)?.get(SelectionFrameComponent)?.deselect()
     }
 
     isSelectable(): boolean {

--- a/src/game/system/DeathSystem.ts
+++ b/src/game/system/DeathSystem.ts
@@ -2,7 +2,7 @@ import { AbstractGameSystem, GameEntity } from '../ECS'
 import { HealthComponent } from '../component/HealthComponent'
 import { LastWillComponent } from '../component/LastWillComponent'
 import { SelectionFrameComponent } from '../component/SelectionFrameComponent'
-import { SelectionChanged } from '../../event/LocalEvents'
+import { DeselectAll } from '../../event/LocalEvents'
 import { WorldManager } from '../WorldManager'
 import { EventBroker } from '../../event/EventBroker'
 
@@ -25,8 +25,7 @@ export class DeathSystem extends AbstractGameSystem {
                     components.get(LastWillComponent).onDeath()
                     this.ecs.removeComponent(entity, LastWillComponent)
                     if (selectionFrameComponent?.isSelected()) {
-                        selectionFrameComponent.deselect()
-                        EventBroker.publish(new SelectionChanged(this.worldMgr.entityMgr))
+                        EventBroker.publish(new DeselectAll())
                     }
                 }
             } catch (e) {


### PR DESCRIPTION
When the currently selected building/vehicle gets destroyed, the game breaks because it's impossible to close the panel (null error).
This PR fixes the null error and additionally auto-closes the panel when the entity dies.