### PR TITLE
Remove duplicated wheel meshes

### DIFF
--- a/src/scene/AnimatedSceneEntity.ts
+++ b/src/scene/AnimatedSceneEntity.ts
@@ -130,6 +130,7 @@ export class AnimatedSceneEntity extends SceneEntity {
         this.meshesByLName.clear()
         this.installedUpgrades.forEach((e) => e.parent.remove(e.child))
         this.installedUpgrades.length = 0
+        this.wheelJoints.forEach((e) => e.mesh.removeFromParent())
         this.wheelJoints.length = 0
         this.carryJoints.length = 0
         if (this.driverParent && this.driver) this.driverParent.remove(this.driver)


### PR DESCRIPTION
Wheel meshes are added to vehicles every time the animation changes, but they are never removed.
This causes the rendering to slow down after a while because of the high triangle count.