### PR TITLE
Fix rubble created by rockies

### DIFF
--- a/src/game/system/RockMonsterBehaviorSystem.ts
+++ b/src/game/system/RockMonsterBehaviorSystem.ts
@@ -120,7 +120,7 @@ export class RockMonsterBehaviorSystem extends AbstractGameSystem {
                                 }
                                 sceneEntity.setAnimation(AnimEntityActivity.Stand)
                             }, 0, () => {
-                                positionComponent.surface.setSurfaceType(SurfaceType.RUBBLE4)
+                                positionComponent.surface.makeRubble(0, true)
                                 this.worldMgr.sceneMgr.addMiscAnim(GameConfig.instance.miscObjects.SmashPath, positionComponent.surface.getCenterWorld(), 0, false)
                             })
                         } else {
@@ -241,7 +241,7 @@ export class RockMonsterBehaviorSystem extends AbstractGameSystem {
                                 }
                                 sceneEntity.setAnimation(AnimEntityActivity.Stand)
                             }, 0, () => {
-                                positionComponent.surface.setSurfaceType(SurfaceType.RUBBLE4)
+                                positionComponent.surface.makeRubble(0, true)
                                 this.worldMgr.sceneMgr.addMiscAnim(GameConfig.instance.miscObjects.SmashPath, positionComponent.surface.getCenterWorld(), 0, false)
                             })
                         } else {
@@ -306,7 +306,7 @@ export class RockMonsterBehaviorSystem extends AbstractGameSystem {
                                 }
                                 sceneEntity.setAnimation(AnimEntityActivity.Stand)
                             }, 0, () => {
-                                positionComponent.surface.setSurfaceType(SurfaceType.RUBBLE4)
+                                positionComponent.surface.makeRubble(0, true)
                                 this.worldMgr.sceneMgr.addMiscAnim(GameConfig.instance.miscObjects.SmashPath, positionComponent.surface.getCenterWorld(), 0, false)
                             })
                         } else {

--- a/src/game/terrain/Surface.ts
+++ b/src/game/terrain/Surface.ts
@@ -542,8 +542,8 @@ export class Surface {
         ]
     }
 
-    makeRubble(containedOre: number = 0) {
-        if (this.surfaceType.rubbleResilient) return
+    makeRubble(containedOre: number = 0, force: boolean = false) {
+        if (this.surfaceType.rubbleResilient && !force) return
         this.rubblePositions = [this.getRandomPosition(), this.getRandomPosition(), this.getRandomPosition(), this.getRandomPosition()]
         this.containedOres += containedOre
         this.setSurfaceType(SurfaceType.RUBBLE4)


### PR DESCRIPTION
It's not possible to clear the rubble because `rubblePositions` is empty