### PR TITLE
Update hidden cavern that is already discovered

### DIFF
--- a/src/game/terrain/Surface.ts
+++ b/src/game/terrain/Surface.ts
@@ -116,7 +116,7 @@ export class Surface {
             surface.markDiscovered()
             for (const neighbor of surface.neighbors8) {
                 if (neighbor.surfaceType.floor || neighbor.surfaceType === SurfaceType.HIDDEN_CAVERN || neighbor.surfaceType === SurfaceType.HIDDEN_SLUG_HOLE) {
-                    if (!neighbor.discovered) {
+                    if (!neighbor.discovered || neighbor.surfaceType === SurfaceType.HIDDEN_CAVERN || neighbor.surfaceType === SurfaceType.HIDDEN_SLUG_HOLE) {
                         stack.push(neighbor)
                         caveFound = true
                     }


### PR DESCRIPTION
Level 23 starts with a HIDDEN_SLUG_HOLE that is already discovered:
![discovered HIDDEN_SLUG_HOLE](https://github.com/user-attachments/assets/d225b5b7-90fe-422b-9906-bc5a646b74f3)
![Update Bug](https://github.com/user-attachments/assets/f4e18080-5ebb-4ae8-98db-0f3d87486af5)
