### PR TITLE
Add FluidSurfaceComponent to discovered surfaces

### DIFF
--- a/src/game/TerrainLoader.ts
+++ b/src/game/TerrainLoader.ts
@@ -56,10 +56,6 @@ export class TerrainLoader {
                         surface.containedOres = currentCryOre / 2
                     }
                 }
-                if (surfaceType === SurfaceType.WATER || surfaceType === SurfaceType.LAVA5) {
-                    surface.mesh.geometry.computeVertexNormals()
-                    worldMgr.ecs.addComponent(surface.entity, new FluidSurfaceComponent(surface.x, surface.y, surface.mesh.geometry.attributes.uv))
-                }
 
                 terrain.surfaces[c].push(surface)
             }
@@ -84,6 +80,11 @@ export class TerrainLoader {
                             surface.discovered = true
                             if (surface.neighbors.some((n) => n.surfaceType.floor)) {
                                 switch (surface.surfaceType) {
+                                    case SurfaceType.LAVA5:
+                                        // fallthrough
+                                    case SurfaceType.WATER:
+                                        worldMgr.ecs.addComponent(surface.entity, new FluidSurfaceComponent(surface.x, surface.y, surface.mesh.geometry.attributes.uv))
+                                        break
                                     case SurfaceType.SLUG_HOLE:
                                         terrain.slugHoles.add(surface)
                                         break

--- a/src/game/terrain/Surface.ts
+++ b/src/game/terrain/Surface.ts
@@ -137,6 +137,11 @@ export class Surface {
     private markDiscovered() {
         if (this.neighbors8.some((n) => n.discovered && n.surfaceType.floor)) {
             switch (this.surfaceType) {
+                case SurfaceType.LAVA5:
+                    // fallthrough
+                case SurfaceType.WATER:
+                    this.worldMgr.ecs.addComponent(this.entity, new FluidSurfaceComponent(this.x, this.y, this.mesh.geometry.attributes.uv))
+                    break
                 case SurfaceType.HIDDEN_CAVERN:
                     this.surfaceType = SurfaceType.GROUND
                     this.needsMeshUpdate = true


### PR DESCRIPTION
This PR fixes an issue where FluidSurfaceComponent is added to surfaces that are not yet discovered, causing them to move:
![Image](https://github.com/user-attachments/assets/9ad7c107-7f4a-4440-b236-787f3bde49e8)