### PR TITLE
Use nearest-neighbor interpolation

### DIFF
--- a/src/resource/ResourceManager.ts
+++ b/src/resource/ResourceManager.ts
@@ -1,4 +1,4 @@
-import { BufferGeometry, RepeatWrapping, SRGBColorSpace, Texture } from 'three'
+import { BufferGeometry, NearestFilter, RepeatWrapping, SRGBColorSpace, Texture } from 'three'
 import { getFilename, getPath } from '../core/Util'
 import { VERBOSE } from '../params'
 import { SceneMesh } from '../scene/SceneMesh'
@@ -167,6 +167,7 @@ export class ResourceManager {
             texture.name = textureFilepath
             texture.needsUpdate = true // without everything is just dark
             texture.colorSpace = SRGBColorSpace
+            texture.magFilter = NearestFilter
             return texture
         })
     }


### PR DESCRIPTION
The original game uses nearest-neighbor interpolation for the textures.
Linear interpolation looks better in some cases, but the textures are not designed for it. E.g. they look blurred instead of showing clear brick boundaries.

Nearest:
![nearest](https://github.com/user-attachments/assets/41f08187-d0a4-42bf-a42f-e01241ad4e04)

Linear:
![linear](https://github.com/user-attachments/assets/07cd5a1d-6272-4c83-a89e-d2bab712c6ae)
