### PR TITLE
Remove retreated monsters from the radar

### DIFF
--- a/src/game/system/RockMonsterBehaviorSystem.ts
+++ b/src/game/system/RockMonsterBehaviorSystem.ts
@@ -33,6 +33,8 @@ import { BeamUpComponent } from '../component/BeamUpComponent'
 import { GameConfig } from '../../cfg/GameConfig'
 import { EventBroker } from '../../event/EventBroker'
 import { PRNG } from '../factory/PRNG'
+import { UpdateRadarEntityEvent } from '../../event/LocalEvents'
+import { MapMarkerChange, MapMarkerType } from '../component/MapMarkerComponent'
 
 const ROCKY_GRAB_DISTANCE_SQ = 10 * 10
 const ROCKY_GATHER_DISTANCE_SQ = 5 * 5
@@ -364,6 +366,7 @@ export class RockMonsterBehaviorSystem extends AbstractGameSystem {
                                 sceneEntity.setAnimation(RockMonsterActivity.Enter, () => {
                                     GameState.totalCrystals -= behaviorComponent.numCrystalsEaten
                                     EventBroker.publish(new WorldLocationEvent(EventKey.LOCATION_MONSTER_GONE, positionComponent))
+                                    EventBroker.publish(new UpdateRadarEntityEvent(MapMarkerType.MONSTER, entity, MapMarkerChange.REMOVE))
                                     this.worldMgr.sceneMgr.disposeSceneEntity(sceneEntity)
                                     this.ecs.removeEntity(entity)
                                 })

--- a/src/game/system/SlugBehaviorSystem.ts
+++ b/src/game/system/SlugBehaviorSystem.ts
@@ -20,6 +20,8 @@ import { EntityPushedComponent } from '../component/EntityPushedComponent'
 import { HeadingComponent } from '../component/HeadingComponent'
 import { EventBroker } from '../../event/EventBroker'
 import { PRNG } from '../factory/PRNG'
+import { UpdateRadarEntityEvent } from '../../event/LocalEvents'
+import { MapMarkerChange, MapMarkerType } from '../component/MapMarkerComponent'
 
 const SLUG_SUCK_DISTANCE_SQ = 25 * 25
 const SLUG_ENTER_DISTANCE_SQ = 5 * 5
@@ -132,6 +134,7 @@ export class SlugBehaviorSystem extends AbstractGameSystem {
                             this.worldMgr.entityMgr.removeEntity(entity)
                             sceneEntity.setAnimation(SlugActivity.Enter, () => {
                                 EventBroker.publish(new WorldLocationEvent(EventKey.LOCATION_SLUG_GONE, positionComponent))
+                                EventBroker.publish(new UpdateRadarEntityEvent(MapMarkerType.MONSTER, entity, MapMarkerChange.REMOVE))
                                 this.worldMgr.sceneMgr.disposeSceneEntity(sceneEntity)
                                 this.ecs.removeEntity(entity)
                             })


### PR DESCRIPTION
Monsters are only taken off the radar when they die, not when they have gone home.