### PR TITLE
Use the first conflicting config key (case-insensitive)

### DIFF
--- a/src/cfg/CfgEntry.ts
+++ b/src/cfg/CfgEntry.ts
@@ -5,7 +5,13 @@ export class CfgEntry {
     }
 
     forEachEntry(callback: (key: string, entry: CfgEntry) => void): void {
+        const visitedKeys = new Set<string>()
         Object.entries(this.root).forEach(([key, value]) => {
+            const unifiedKey = CfgEntry.unifyKey(key)
+            if (visitedKeys.has(unifiedKey)) {
+                return
+            }
+            visitedKeys.add(unifiedKey)
             if (Array.isArray(value)) {
                 // No warning here, because some like "PausedMenu" has mixture of MenuCount value and records
                 return
@@ -15,7 +21,13 @@ export class CfgEntry {
     }
 
     forEachCfgEntryValue(callback: (value: CfgEntryValue, key: string) => void): void {
+        const visitedKeys = new Set<string>()
         Object.entries(this.root).forEach(([key, value]) => {
+            const unifiedKey = CfgEntry.unifyKey(key)
+            if (visitedKeys.has(unifiedKey)) {
+                return
+            }
+            visitedKeys.add(unifiedKey)
             if (!Array.isArray(value)) {
                 console.warn(`Unexpected object (${value}) given; expected config values`)
                 return
@@ -59,7 +71,6 @@ export class CfgEntry {
     }
 
     private static unifyKey(keyValue: string) {
-        // TODO Keys actually case-sensitive (see UpgradeTypes -> SPEED_up for hoverboard VS Speed_Up for small cat
         return keyValue.toString().toLowerCase().replaceAll(/[_-]/g, '')
     }
 


### PR DESCRIPTION
Use the first conflicting config key (case-insensitive) to match original game behavior.

There are two conflicting configuration keys: SPEED_up and Speed_Up.  Only the first is actually used.

Fixes #48 